### PR TITLE
Allow manually running LSST tests

### DIFF
--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -7,6 +7,7 @@ on:
       - main
       - master
   pull_request: null
+  workflow_dispatch: null
   schedule:
     - cron: 0 23 * * 4
 


### PR DESCRIPTION
GitHub disables the cron scheduled GitHub Actions runs after three months of inactivity. If we suspect that the tests might be broken, either due to bitrot or not precise enough for shear, we will need to run the workflow manually.

YOLO ing this without a Jira ticket because i) this is a fork that doesn't obey the same conventions as LSST repos ii) the change is not in the code and is trivial enough iii) this is in `lsst-dm` organization and is not part of `lsst_distrib` build.