### PR TITLE
DO NOT MERGE: Refactor the top-most level of LSST metadetect

### DIFF
--- a/.github/workflows/lsst-tests-ngmix-upstream.yml
+++ b/.github/workflows/lsst-tests-ngmix-upstream.yml
@@ -38,8 +38,8 @@ jobs:
           conda install --quiet --yes --file requirements.txt
           conda install --quiet --yes --file dev-requirements.txt
           conda install -q -y stackvana=0 lsstdesc-weaklensingdeblending
+          conda install lsstdesc-wl-shear-sims
 
-          pip install --no-deps git+https://github.com/LSSTDESC/descwl-shear-sims.git
           pip install --no-deps git+https://github.com/LSSTDESC/descwl_coadd.git
 
           python -m pip install -e .

--- a/.github/workflows/lsst-tests-ngmix-upstream.yml
+++ b/.github/workflows/lsst-tests-ngmix-upstream.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests-ngmix-upstream
     strategy:
       matrix:
-        pyver: ["3.11"]
+        pyver: ["3.11", "3.12"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/lsst-tests-ngmix-upstream.yml
+++ b/.github/workflows/lsst-tests-ngmix-upstream.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests-ngmix-upstream
     strategy:
       matrix:
-        pyver: ["3.11", "3.12"]
+        pyver: ["3.11"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -38,8 +38,8 @@ jobs:
           conda install --quiet --yes --file requirements.txt
           conda install --quiet --yes --file dev-requirements.txt
           conda install -q -y stackvana=0 lsstdesc-weaklensingdeblending
+          conda install lsstdesc-wl-shear-sims
 
-          pip install --no-deps git+https://github.com/LSSTDESC/descwl-shear-sims.git
           pip install --no-deps git+https://github.com/LSSTDESC/descwl_coadd.git
 
           python -m pip install -e .

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests
     strategy:
       matrix:
-        pyver: ["3.11"]
+        pyver: ["3.11", "3.12"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: lsst-tests
     strategy:
       matrix:
-        pyver: ["3.11", "3.12"]
+        pyver: ["3.11"]
 
     runs-on: "ubuntu-latest"
 

--- a/metadetect/lsst/README.md
+++ b/metadetect/lsst/README.md
@@ -1,0 +1,20 @@
+# Metadetect for Rubin Observatory / LSST
+
+This subpackage contains code for running metadetect on data structures and algorithms available from the Rubin Science Pipelines.
+
+## Config framework
+
+### Overview of the config framework in Rubin Science Pipelines
+The algorithms within Rubin Science Pipelines are implemented as `Task`s and `PipelineTask`s, each with an associate `Config` object.
+This architecture allows using the same algorithm in multiple places, configured appropriately as required.
+Thus, a `Config` object is initially mutable.
+The default values are specified in the individual fields and they can be overridden in a special method called `setDefaults`.
+However, once the `freeze` method is called, it becomes immutable (via public methods) and the values cannot be changed any further.
+After a `Config` instance is frozen, its `validate` method is called to check that the configuration is valid one.
+This is intended to check the data types and relationships between the fields.
+When run as part of the pipelines, the pipeline execution (or `pex`) in Rubin Science Pipelines will call these methods before beginning the execution and persist them along with the processing runs for reproducibility.
+
+### Use of Config framework in metadetect
+The `metadetect` algorithm are also implemented as `Task`s with thin-wrappers around them for backwards compatibility.
+The `Task` entry points are intended to be used in production, whereas the top-level wrapper functions continue to serve as entry points for on-the-fly simulations with other packages (e.g., [descwl-shear-sims](https://github.com/LSSTDESC/descwl-shear-sims) and [descwl_coadd](https://github.com/LSSTDESC/descwl_coadd)).
+In order to prevent changes to the default values upstream going unnoticed and affecting the performance of `metadetect`, the unit tests in `tests/test_lsst_dm_configs.py` check that the `Config` objects what they have been validated on simulations.

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -102,7 +102,6 @@ class DetectAndDeblendConfig(Config):
         self.detect.includeThresholdMultiplier = 1.0
         self.detect.thresholdPolarity = "positive"
         self.detect.adjustBackground = 0.0
-        self.detect.reEstimateBackground = True
         # these are ignored since we are doing reEstimateBackground = False
         # detection_config.background
         # detection_config.tempLocalBackground

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -37,6 +37,7 @@ def detect_and_deblend(
     rng,
     thresh=DEFAULT_THRESH,
     show=False,
+    config=None,
 ):
     """
     run detection and deblending of peaks, as well as basic measurments such as

--- a/metadetect/lsst/measure.py
+++ b/metadetect/lsst/measure.py
@@ -5,12 +5,16 @@ import esutil as eu
 import ngmix
 
 import lsst.afw.table as afw_table
-from lsst.meas.algorithms import SourceDetectionTask, SourceDetectionConfig
+from lsst.meas.algorithms import SourceDetectionTask
+from lsst.meas.algorithms import SourceDetectionConfig as OriginalSourceDetectionConfig
 from lsst.meas.deblender import SourceDeblendTask, SourceDeblendConfig
 from lsst.meas.base import (
     SingleFrameMeasurementConfig,
     SingleFrameMeasurementTask,
 )
+from lsst.pex.config import Config, ConfigurableField, Field
+from lsst.pipe.base import Task
+import lsst.afw.image as afw_image
 import lsst.geom as geom
 from lsst.pex.exceptions import (
     InvalidParameterError,
@@ -23,7 +27,7 @@ from ..procflags import (
 from ..fitting import fit_mbobs_wavg, get_wavg_output_struct
 
 from . import util
-from .util import ContextNoiseReplacer
+from .util import ContextNoiseReplacer, get_jacobian
 from . import vis
 from .defaults import DEFAULT_THRESH
 
@@ -32,9 +36,162 @@ warnings.filterwarnings('ignore', category=FutureWarning)
 LOG = logging.getLogger('lsst_measure')
 
 
+class SourceDetectionConfig(OriginalSourceDetectionConfig):
+    @property
+    def thresh(self):
+        return self.thresholdValue
+
+    @thresh.setter
+    def thresh(self, value):
+        self.thresholdValue = value
+
+
+SourceDetectionTask.ConfigClass = SourceDetectionConfig
+
+
+class DetectAndDeblendConfig(Config):
+    meas = ConfigurableField[SingleFrameMeasurementConfig](
+        doc="Measurement config",
+        target=SingleFrameMeasurementTask,
+    )
+
+    detect = ConfigurableField[SourceDetectionConfig](
+        doc="Detection config",
+        target=SourceDetectionTask
+    )
+
+    deblend = ConfigurableField[SourceDeblendConfig](
+        doc="Deblend config",
+        target=SourceDeblendTask
+    )
+
+    seed = Field[int](
+        doc="Random rng seed",
+        default=42,
+    )
+
+    def setDefaults(self):
+        super().setDefaults()
+
+        # defaults for measurement config
+        self.meas.plugins.names = [
+            "base_SdssCentroid",
+            "base_PsfFlux",
+            "base_SkyCoord",
+        ]
+
+        # set these slots to none because we aren't running these algorithms
+        self.meas.slots.apFlux = None
+        self.meas.slots.gaussianFlux = None
+        self.meas.slots.calibFlux = None
+        self.meas.slots.modelFlux = None
+
+        # goes with SdssShape above
+        self.meas.slots.shape = None
+
+        # fix odd issue where it things things are near the edge
+        self.meas.plugins['base_SdssCentroid'].binmax = 1
+
+        # defaults for detection config
+        # DM does not have config default stability.  Set all of them explicitly
+        self.detect.minPixels = 1
+        self.detect.isotropicGrow = True
+        self.detect.combinedGrow = True
+        self.detect.nSigmaToGrow = 2.4
+        self.detect.returnOriginalFootprints = False
+        self.detect.includeThresholdMultiplier = 1.0
+        self.detect.thresholdPolarity = "positive"
+        self.detect.adjustBackground = 0.0
+        self.detect.reEstimateBackground = True
+        # these are ignored since we are doing reEstimateBackground = False
+        # detection_config.background
+        # detection_config.tempLocalBackground
+        # detection_config.doTempLocalBackground
+        # detection_config.tempWideBackground
+        # detection_config.doTempWideBackground
+        self.detect.nPeaksMaxSimple = 1
+        self.detect.nSigmaForKernel = 7.0
+        self.detect.excludeMaskPlanes = util.get_detection_mask()
+
+        # the defaults changed from from stdev to pixel_std but
+        # we don't want that
+
+        self.detect.thresholdType = "stdev"
+        # our changes from defaults
+        self.detect.reEstimateBackground = False
+
+        self.detect.thresholdValue = DEFAULT_THRESH
+
+        # these will be ignored when finding the image standard deviation
+        self.detect.statsMask = util.get_stats_mask()
+
+        # deblend config
+        # these tasks must use the same schema and all be constructed before any
+        # other tasks using the same schema are run because schema is modified in
+        # place by tasks, and the constructor does a check that fails if we do this
+        # afterward
+        self.deblend.maxFootprintArea = 0
+
+
+class DetectAndDeblendTask(Task):
+    ConfigClass = DetectAndDeblendConfig
+    _DefaultName = "detect_and_deblend"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        schema = afw_table.SourceTable.makeMinimalSchema()
+        self.makeSubtask("meas", schema=schema)
+        self.makeSubtask("detect", schema=schema)
+        self.makeSubtask("deblend", schema=schema)
+        self.rng = np.random.RandomState(seed=self.config.seed)
+
+    def run(self, mbexp, show=False):
+        if len(mbexp.singles) > 1:
+            detexp = util.coadd_exposures(mbexp.singles)
+            if detexp is None:
+                return [], None
+        else:
+            detexp = mbexp.singles[0]
+
+        # background measurement within the detection code requires ExposureF
+        if not isinstance(detexp, afw_image.ExposureF):
+            detexp = afw_image.ExposureF(detexp, deep=True)
+
+        schema = self.deblend.schema  # should be the same for all tasks
+        afw_table.CoordKey.addErrorFields(schema)
+        table = afw_table.SourceTable.make(schema)
+        result = self.detect.run(table, detexp)
+
+        if result is not None:
+            sources = result.sources
+            self.deblend.run(detexp, sources)
+
+            with ContextNoiseReplacer(
+                detexp, sources, self.rng, config=self.meas.config.noiseReplacer
+            ) as replacer:
+
+                for source in sources:
+
+                    if source.get('deblend_nChild') != 0:
+                        continue
+
+                    source_id = source.getId()
+
+                    with replacer.sourceInserted(source_id):
+                        self.meas.callMeasure(source, detexp)
+
+        else:
+            sources = []
+
+        if show:
+            vis.show_exp(detexp, use_mpl=True, sources=sources)
+
+        return sources, detexp
+
+
 def detect_and_deblend(
     mbexp,
-    rng,
+    rng=None,
     thresh=DEFAULT_THRESH,
     show=False,
     config=None,
@@ -63,123 +220,23 @@ def detect_and_deblend(
     sources, detexp
         The sources and the detection exposure
     """
-    import lsst.afw.image as afw_image
+    config_override = config if config is not None else {}
+    if thresh:
+        if 'detect' not in config_override:
+            config_override['detect'] = {}
+        config_override['detect']['thresholdValue'] = thresh
 
-    if len(mbexp.singles) > 1:
-        detexp = util.coadd_exposures(mbexp.singles)
-        if detexp is None:
-            return [], None
-    else:
-        detexp = mbexp.singles[0]
+    config = DetectAndDeblendConfig()
+    config.setDefaults()
 
-    # background measurement within the detection code requires ExposureF
-    if not isinstance(detexp, afw_image.ExposureF):
-        detexp = afw_image.ExposureF(detexp, deep=True)
+    util.override_config(config, config_override)
 
-    schema = afw_table.SourceTable.makeMinimalSchema()
-
-    # Setup algorithms to run
-    meas_config = SingleFrameMeasurementConfig()
-    meas_config.plugins.names = [
-        "base_SdssCentroid",
-        "base_PsfFlux",
-        "base_SkyCoord",
-    ]
-
-    # set these slots to none because we aren't running these algorithms
-    meas_config.slots.apFlux = None
-    meas_config.slots.gaussianFlux = None
-    meas_config.slots.calibFlux = None
-    meas_config.slots.modelFlux = None
-
-    # goes with SdssShape above
-    meas_config.slots.shape = None
-
-    # fix odd issue where it things things are near the edge
-    meas_config.plugins['base_SdssCentroid'].binmax = 1
-
-    meas_task = SingleFrameMeasurementTask(
-        config=meas_config,
-        schema=schema,
-    )
-    # avoids a warning spamming for every object
-    afw_table.CoordKey.addErrorFields(schema)
-
-    detection_config = SourceDetectionConfig()
-
-    # DM does not have config default stability.  Set all of them explicitly
-    detection_config.minPixels = 1
-    detection_config.isotropicGrow = True
-    detection_config.combinedGrow = True
-    detection_config.nSigmaToGrow = 2.4
-    detection_config.returnOriginalFootprints = False
-    detection_config.includeThresholdMultiplier = 1.0
-    detection_config.thresholdPolarity = "positive"
-    detection_config.adjustBackground = 0.0
-    detection_config.reEstimateBackground = True
-    # these are ignored since we are doing reEstimateBackground = False
-    # detection_config.background
-    # detection_config.tempLocalBackground
-    # detection_config.doTempLocalBackground
-    # detection_config.tempWideBackground
-    # detection_config.doTempWideBackground
-
-    detection_config.nPeaksMaxSimple = 1
-    detection_config.nSigmaForKernel = 7.0
-    detection_config.excludeMaskPlanes = util.get_detection_mask(detexp)
-
-    # the defaults changed from from stdev to pixel_std but
-    # we don't want that
-
-    detection_config.thresholdType = "stdev"
-    # our changes from defaults
-    detection_config.reEstimateBackground = False
-
-    detection_config.thresholdValue = thresh
-
-    # these will be ignored when finding the image standard deviation
-    detection_config.statsMask = util.get_stats_mask(detexp)
-
-    detection_task = SourceDetectionTask(config=detection_config)
-
-    # these tasks must use the same schema and all be constructed before any
-    # other tasks using the same schema are run because schema is modified in
-    # place by tasks, and the constructor does a check that fails if we do this
-    # afterward
-    deblend_config = SourceDeblendConfig()
-    deblend_config.maxFootprintArea = 0
-    deblend_task = SourceDeblendTask(
-        config=deblend_config,
-        schema=schema,
-    )
-
-    table = afw_table.SourceTable.make(schema)
-
-    result = detection_task.run(table, detexp)
-
-    if result is not None:
-        sources = result.sources
-        deblend_task.run(detexp, sources)
-
-        with ContextNoiseReplacer(detexp, sources, rng) as replacer:
-
-            for source in sources:
-
-                if source.get('deblend_nChild') != 0:
-                    continue
-
-                source_id = source.getId()
-
-                with replacer.sourceInserted(source_id):
-                    meas_task.callMeasure(source, detexp)
-
-    else:
-        sources = []
-
-    if show:
-        vis.show_exp(detexp, use_mpl=True, sources=sources)
-
-    return sources, detexp
+    config.freeze()
+    config.validate()
+    task = DetectAndDeblendTask(config=config)
+    if rng is not None:
+        task.rng = rng
+    return task.run(mbexp, show)
 
 
 def measure(
@@ -595,7 +652,6 @@ def _extract_jacobian_at_source(exp, source):
     Jacobian: ngmix.Jacobian
         The local jacobian
     """
-    from .util import get_jacobian
 
     orig_cen = exp.getWcs().skyToPixel(source.getCoord())
 
@@ -699,8 +755,6 @@ def get_output(wcs, source, res, bmask, stamp_size, exp_bbox):
     ndarray
         Has the fields from res, with new fields added, see get_output_dtype
     """
-    import lsst.afw.image as afw_image
-
     output = get_output_struct(res)
 
     orig_cen = source.getCentroid()

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -90,15 +90,15 @@ def run_metadetect(
 
 class WeightConfig(Config):
     fwhm = Field[float](
-        doc="FWHM of the Gaussian weight function (in pixel units)",
+        doc="FWHM of the Gaussian weight function (in arcseconds)",
         default=None,
     )
     fwhm_smooth = Field[float](
-        doc="FWHM of the Gaussian smoothing function (in pixel units)",
+        doc="FWHM of the Gaussian smoothing function (in arcseconds)",
         default=DEFAULT_FWHM_SMOOTH,
     )
     fwhm_reg = Field[float](
-        doc="FWHM of the Gaussian regularization function (in pixel units)",
+        doc="FWHM of the Gaussian regularization function (in arcseconds)",
         default=DEFAULT_FWHM_REG,
     )
 
@@ -183,7 +183,7 @@ class MetadetectConfig(Config):
     )
 
     weight = ConfigField[WeightConfig](
-        doc="FWHM of the Gaussian weight function (in pixel units)",
+        doc="FWHM of the Gaussian weight function (in arcseconds)",
     )
 
     psf = ConfigField[PsfConfig](

--- a/metadetect/lsst/skysub.py
+++ b/metadetect/lsst/skysub.py
@@ -4,23 +4,13 @@ from lsst.meas.algorithms import (
     SubtractBackgroundConfig,
     SourceDetectionTask,
 )
-from lsst.meas.algorithms import SourceDetectionConfig as OriginalSourceDetectionConfig
 from lsst.pex.config import Config, ConfigurableField, Field
 from lsst.pex.exceptions import RuntimeError as LSSTRuntimeError
 from lsst.pipe.base import Task, TaskError
 
 from .defaults import DEFAULT_THRESH
+from .measure import SourceDetectionConfig
 from . import util
-
-
-class SourceDetectionConfig(OriginalSourceDetectionConfig):
-    @property
-    def thresholdValue(self):
-        return self.thresholdValue
-
-    @thresholdValue.setter
-    def thresholdValue(self, value):
-        self.thresholdValue = value
 
 
 SourceDetectionTask.ConfigClass = SourceDetectionConfig

--- a/metadetect/lsst/skysub.py
+++ b/metadetect/lsst/skysub.py
@@ -30,7 +30,7 @@ def determine_and_subtract_sky(exp):
     return background
 
 
-def subtract_sky_mbexp(mbexp, thresh=DEFAULT_THRESH):
+def subtract_sky_mbexp(mbexp, thresh=DEFAULT_THRESH, config=None):
     """
     subtract sky
 
@@ -49,7 +49,7 @@ def subtract_sky_mbexp(mbexp, thresh=DEFAULT_THRESH):
 
 
 def iterate_detection_and_skysub(
-    exposure, thresh, niter=2,
+    exposure, thresh, niter=2, config=None
 ):
     """
     Iterate detection and sky subtraction

--- a/metadetect/lsst/skysub.py
+++ b/metadetect/lsst/skysub.py
@@ -205,14 +205,3 @@ def iterate_detection_and_skysub(
     task = IterateDetectionSkySubTask(config=config)
     result = task.run(exposure)
     return result
-
-
-class SkySubtractionTask(Task):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.makeSubtask("subtract_background")
-        self.makeSubtask("detect_sources")
-
-    def run(self, exposure, **kwargs):
-        return self._sky_sub(exposure, **kwargs)

--- a/metadetect/lsst/skysub.py
+++ b/metadetect/lsst/skysub.py
@@ -3,11 +3,122 @@ from lsst.meas.algorithms import (
     SubtractBackgroundTask,
     SubtractBackgroundConfig,
     SourceDetectionTask,
-    SourceDetectionConfig,
 )
+from lsst.meas.algorithms import SourceDetectionConfig as OriginalSourceDetectionConfig
+from lsst.pex.config import Config, ConfigurableField, Field
+from lsst.pex.exceptions import RuntimeError as LSSTRuntimeError
+from lsst.pipe.base import Task, TaskError
 
 from .defaults import DEFAULT_THRESH
 from . import util
+
+
+class SourceDetectionConfig(OriginalSourceDetectionConfig):
+    @property
+    def thresholdValue(self):
+        return self.thresholdValue
+
+    @thresholdValue.setter
+    def thresholdValue(self, value):
+        self.thresholdValue = value
+
+
+SourceDetectionTask.ConfigClass = SourceDetectionConfig
+
+
+class IterateDetectionSkySubConfig(Config):
+    niter = Field[int](
+        doc="Number of iterations",
+        default=2,
+    )
+
+    detect = ConfigurableField[SourceDetectionConfig](
+        doc="Detection config",
+        target=SourceDetectionTask
+    )
+
+    back = ConfigurableField[SubtractBackgroundConfig](
+        doc="Subtract background config",
+        target=SubtractBackgroundTask
+    )
+
+    def setDefaults(self):
+        super().setDefaults()
+
+        # detection
+        self.detect.reEstimateBackground = False
+        self.detect.thresholdValue = DEFAULT_THRESH
+
+        # background subtraction
+        bp_to_skip = util.get_stats_mask()
+        self.back = SubtractBackgroundConfig(ignoredPixelMask=bp_to_skip)
+
+
+class IterateDetectionSkySubTask(Task):
+    ConfigClass = IterateDetectionSkySubConfig
+    _DefaultName = "iterate_detection_and_skysub"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.makeSubtask("detect")
+        self.makeSubtask("back")
+
+    def run(self, exposure):
+        if self.config.niter < 1:
+            raise ValueError(f'niter {self.config.niter} is less than 1')
+
+        schema = afw_table.SourceTable.makeMinimalSchema()
+        table = afw_table.SourceTable.make(schema)
+
+        # keep a running sum of each sky that was subtracted
+        try:
+            sky_meas = 0.0
+            for i in range(self.config.niter):
+                self.back.run(exposure)
+                result = self.detect.run(table, exposure)
+
+                sky_meas += exposure.getMetadata()['BGMEAN']
+
+            meta = exposure.getMetadata()
+
+            # this is the overall sky we subtracted in all iterations
+            meta['BGMEAN'] = sky_meas
+        except LSSTRuntimeError as err:
+            err = str(err).replace('lsst::pex::exceptions::RuntimeError:', '')
+            self.detect.log.warn(err)
+            result = None
+        except TaskError as err:
+            err = str(err).replace('lsst.pipe.base.task.TaskError:', '')
+            self.detect.log.warn(err)
+            result = None
+
+        return result
+
+
+class SubtractSkyMbExpConfig(Config):
+    iterate_detection_and_skysub = ConfigurableField[IterateDetectionSkySubConfig](
+        doc="Iterate detection and sky subtraction config",
+        target=IterateDetectionSkySubTask
+    )
+
+    def setDefaults(self):
+        super().setDefaults()
+
+        self.iterate_detection_and_skysub.detect.thresholdValue = DEFAULT_THRESH
+        self.iterate_detection_and_skysub.niter = 2
+
+
+class SubtractSkyMbExpTask(Task):
+    ConfigClass = SubtractSkyMbExpConfig
+    _DefaultName = "subtract_sky_mbexp"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.makeSubtask("iterate_detection_and_skysub")
+
+    def run(self, mbexp):
+        for exp in mbexp:
+            self.iterate_detection_and_skysub.run(exposure=exp)
 
 
 def determine_and_subtract_sky(exp):
@@ -41,11 +152,26 @@ def subtract_sky_mbexp(mbexp, thresh=DEFAULT_THRESH, config=None):
     thresh: float
         Threshold for detection
     """
-    for exp in mbexp:
-        iterate_detection_and_skysub(
-            exposure=exp,
-            thresh=thresh,
-        )
+    config_override = config if config is not None else {}
+
+    if thresh:
+        if 'iterate_detection_and_skysub' not in config_override:
+            config_override['iterate_detection_and_skysub'] = {}
+        if 'detect' not in config_override['iterate_detection_and_skysub']:
+            config_override['iterate_detection_and_skysub']['detect'] = {}
+
+        detect_override = config_override['iterate_detection_and_skysub']['detect']
+        detect_override['thresholdValue'] = thresh
+
+    config = SubtractSkyMbExpConfig()
+    config.setDefaults()
+
+    util.override_config(config, config_override)
+
+    config.freeze()
+    config.validate()
+    task = SubtractSkyMbExpTask(config=config)
+    task.run(mbexp=mbexp)
 
 
 def iterate_detection_and_skysub(
@@ -68,39 +194,35 @@ def iterate_detection_and_skysub(
     -------
     Result from running the detection task
     """
-    from lsst.pex.exceptions import RuntimeError as LSSTRuntimeError
-    from lsst.pipe.base.task import TaskError
     if niter < 1:
         raise ValueError(f'niter {niter} is less than 1')
 
-    schema = afw_table.SourceTable.makeMinimalSchema()
-    detection_config = SourceDetectionConfig()
-    detection_config.reEstimateBackground = False
-    detection_config.thresholdValue = thresh
-    detection_task = SourceDetectionTask(config=detection_config)
+    config_override = config if config is not None else {}
 
-    table = afw_table.SourceTable.make(schema)
+    # set threshold
+    if 'detect' not in config_override:
+        config_override['detect'] = {}
+    config_override['detect']['thresholdValue'] = thresh
 
-    # keep a running sum of each sky that was subtracted
-    try:
-        sky_meas = 0.0
-        for i in range(niter):
-            determine_and_subtract_sky(exposure)
-            result = detection_task.run(table, exposure)
+    if niter:
+        config_override['niter'] = niter
 
-            sky_meas += exposure.getMetadata()['BGMEAN']
+    config = IterateDetectionSkySubConfig()
+    config.setDefaults()
 
-        meta = exposure.getMetadata()
+    util.override_config(config, config_override)
 
-        # this is the overall sky we subtracted in all iterations
-        meta['BGMEAN'] = sky_meas
-    except LSSTRuntimeError as err:
-        err = str(err).replace('lsst::pex::exceptions::RuntimeError:', '')
-        detection_task.log.warn(err)
-        result = None
-    except TaskError as err:
-        err = str(err).replace('lsst.pipe.base.task.TaskError:', '')
-        detection_task.log.warn(err)
-        result = None
-
+    task = IterateDetectionSkySubTask(config=config)
+    result = task.run(exposure)
     return result
+
+
+class SkySubtractionTask(Task):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.makeSubtask("subtract_background")
+        self.makeSubtask("detect_sources")
+
+    def run(self, exposure, **kwargs):
+        return self._sky_sub(exposure, **kwargs)

--- a/metadetect/lsst/util.py
+++ b/metadetect/lsst/util.py
@@ -905,3 +905,31 @@ def extract_multiband_coadd_data(coadd_data_list):
         'mfrac_mbexp': mfrac_mbexp,
         'ormasks': ormasks,
     }
+
+
+def override_config(config, config_override: dict):
+    """Override the values in a Config instance with those in a dict.
+
+    The `config` object can have arbitrary level of nesting, and to override
+    the values, `config_override` should have the same nested structure.
+    To allow for arbitrary nesting, this function calls itself recursively.
+
+    Parameters
+    ----------
+    config : `lsst.pex.config.Config`
+        The configuration object to override.
+    config_override : `dict`
+        The dictionary of values to override the configuration with.
+
+    Raises
+    ------
+    AttributeError
+        Raised if a key in `config_override` is not an attribute of `config`.
+    """
+    for key, value in config_override.items():
+        if isinstance(value, dict):
+            subconfig = getattr(config, key)
+            # Use recursion to allow for arbitrarily nested config objects.
+            override_config(subconfig, value)
+        else:
+            setattr(config, key, value)

--- a/metadetect/lsst/util.py
+++ b/metadetect/lsst/util.py
@@ -797,17 +797,11 @@ def get_integer_center(wcs, bbox, as_double=False):
     return pixcen, skycen
 
 
-def get_stats_mask(exp):
+def get_stats_mask(*args, **kwargs):
     """
-    Get a stats mask for use in getting image statistics.  If BRIGHT
-    is found in the mask plane it is added to the usual
+    Get a stats mask for use in getting image statistics.
 
-    ['BAD', 'EDGE', 'DETECTED', 'DETECTED_NEGATIVE', 'NO_DATA']
-
-    Parameters
-    ----------
-    exp: lsst.afw.image.ExposureF
-        The exposure
+    ['BAD', 'EDGE', 'DETECTED', 'DETECTED_NEGATIVE', 'NO_DATA', 'BRIGHT']
 
     Returns
     -------
@@ -817,39 +811,32 @@ def get_stats_mask(exp):
     # these will be ignored when finding the image standard deviation
     # stats_mask = ['BAD', 'SAT', 'EDGE', 'NO_DATA']
 
-    stats_mask = ['BAD', 'EDGE', 'DETECTED', 'DETECTED_NEGATIVE', 'NO_DATA']
-
-    if 'BRIGHT' in exp.mask.getMaskPlaneDict():
-        stats_mask += ['BRIGHT']
+    import lsst.afw.image as afw_image
+    afw_image.Mask.addMaskPlane('BRIGHT')
+    stats_mask = ['BAD', 'EDGE', 'DETECTED', 'DETECTED_NEGATIVE', 'NO_DATA', 'BRIGHT']
 
     return stats_mask
 
 
-def get_detection_mask(exp=None):
+def get_detection_mask(*args, **kwargs):
     """
     Get a mask for detection. Regions with these flags set will not be searched
     for objects.
 
-    Default is ['EDGE', 'NO_DATA']
+    Default is ['EDGE', 'NO_DATA', 'BRIGHT]
 
     BRIGHT is defined in descwl_coadd, so it is not guaranteed to be present in
-    the global mask bit space.  Only add BRIGHT to detection mask BRIGHT if it
-    is found in the global mask plane dict
-
-    Parameters
-    ----------
-    exp: lsst.afw.image.ExposureF, optional
-        The exposure
+    the global mask bit space.  We add BRIGHT to detection mask. If it already
+    exists, it does not add a new plane and is harmless.
 
     Returns
     -------
     A list of mask planes
     """
 
-    mask = ['EDGE', 'NO_DATA']
-
-    if exp is not None and 'BRIGHT' in exp.mask.getMaskPlaneDict():
-        mask += ['BRIGHT']
+    import lsst.afw.image as afw_image
+    afw_image.Mask.addMaskPlane('BRIGHT')
+    mask = ['EDGE', 'NO_DATA', 'BRIGHT']
 
     return mask
 

--- a/metadetect/lsst/util.py
+++ b/metadetect/lsst/util.py
@@ -25,7 +25,7 @@ class ContextNoiseReplacer(object):
         # do something
     """
 
-    def __init__(self, exposure, sources, rng, noise_image=None):
+    def __init__(self, exposure, sources, rng, config=None, noise_image=None):
         from lsst.meas.base import NoiseReplacerConfig, NoiseReplacer
         import lsst.afw.detection as afw_det
 
@@ -39,11 +39,12 @@ class ContextNoiseReplacer(object):
         # making the field the same for all metacal images we reduce variance in
         # the calculation of the response
 
-        config = NoiseReplacerConfig()
+        if config is None:
+            config = NoiseReplacerConfig()
 
-        # TODO DM needs to fix the crash
-        # config.noiseSource = 'variance'
-        config.noiseSeedMultiplier = rng.randint(0, 2**24)
+            # TODO DM needs to fix the crash
+            # config.noiseSource = 'variance'
+            config.noiseSeedMultiplier = rng.randint(0, 2**24)
 
         if noise_image is None:
             # TODO remove_poisson should be true for real data


### PR DESCRIPTION
 It currently refactors only the top-most level making `run_metadetect`, which is the typical entry point, a wrapper around a `Task`. The extensive coverage with unit tests should make us all feel confident going about such refactoring. The fact that the the unit tests pass without any changes also shows that the public APIs remain unchanged.