### PR TITLE
DM-55012: Set the weights of non-shear-bands to 0

### DIFF
--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -185,8 +185,20 @@ class MetadetectTask(Task):
         config = self.config.toDict()
         config['detect']['thresh'] = self.detect.config.thresholdValue
 
+        shear_bands = config['shear_bands'] or mbexp.bands
+        if not all(band in mbexp.bands for band in shear_bands):
+            raise RuntimeError(
+                "Not all requested bands for shear are available. "
+                f"Bands `{shear_bands}` were requested but the only "
+                f"bands available are `{mbexp.bands}`."
+            )
+
         ormask = combine_ormasks(mbexp, ormasks)
         mfrac, wgts = get_mfrac_mbexp(mbexp=mbexp, mfrac_mbexp=mfrac_mbexp)
+
+        for i, band in enumerate(mbexp.bands):
+            if band not in shear_bands:
+                wgts[i] = 0
 
         if self.config.subtract_sky:
             subtract_sky_mbexp(

--- a/metadetect/lsst/photometry.py
+++ b/metadetect/lsst/photometry.py
@@ -53,8 +53,20 @@ def run_photometry(
 
     config = get_config(config)
 
+    shear_bands = config['shear_bands'] or mbexp.bands
+    if not all(band in mbexp.bands for band in shear_bands):
+        raise RuntimeError(
+            "Not all requested bands for shear are available. "
+            f"Bands `{shear_bands}` were requested but the only "
+            f"bands available are `{mbexp.bands}`."
+        )
+
     ormask = combine_ormasks(mbexp, ormasks)
     mfrac, wgts = get_mfrac_mbexp(mbexp, mfrac_mbexp)
+
+    for i, band in enumerate(mbexp.bands):
+        if band not in shear_bands:
+            wgts[i] = 0
 
     if config['subtract_sky']:
         subtract_sky_mbexp(mbexp=mbexp, thresh=config['detect']['thresh'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[project]
+name = "metadetect"
+dynamic = ["version"]
+
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
@@ -9,6 +13,12 @@ exclude_lines = [
 
 [tool.setuptools]
 packages = ["metadetect"]
+
+[tool.setuptools.dynamic]
+version = { attr = "lsst_versions.get_lsst_version" }
+
+[tool.lsst_versions]
+write_to = "metadetect/version.py"
 
 [tool.pytest.ini_options]
 addopts = "-rs"


### PR DESCRIPTION
This fixes the bug where the average psfrec* quantities were computed over photometry-only bands.