### PR TITLE
DM-54456: Pull in changes from upstream

### DIFF
--- a/.github/workflows/lsst-tests.yml
+++ b/.github/workflows/lsst-tests.yml
@@ -25,6 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        pyver: ["3.13"]
         ngmix: ["ngmix-upstream", "ngmix-released"]
 
     steps:
@@ -48,6 +49,7 @@ jobs:
             show_channel_urls: true
             always_yes: true
           create-args: >-
+            python=${{ matrix.pyver }}
             stackvana=0
             lsstdesc-weaklensingdeblending
             lsstdesc-wl-shear-sims

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     - Update task configs for this limitation
     - Remove unused metacal config parameters
     - keep track of problems with stamp images in separate stamp_flags field
+    - support fitgauss method for getting reconvolution kernel in the lsst
+      sub-package. This is now the default.
 
 ## 0.12.0 - 2023-04-03
 

--- a/metadetect/lsst/defaults.py
+++ b/metadetect/lsst/defaults.py
@@ -17,7 +17,9 @@ DEFAULT_SUBTRACT_SKY = False
 
 # Control of the metacal process
 # currently we don't have any defaults
-DEFAULT_METACAL_CONFIG = {}
+DEFAULT_METACAL_CONFIG = {
+    'reconv_type': 'fitgauss',
+}
 
 # detection config, this may expand
 DEFAULT_DETECT_CONFIG = {

--- a/metadetect/lsst/metacal_exposures.py
+++ b/metadetect/lsst/metacal_exposures.py
@@ -2,7 +2,7 @@
 Code to do metacal with lsst exposures
 """
 import numpy as np
-from ngmix.metacal.metacal import _get_gauss_target_psf
+from ngmix.metacal.metacal import _get_gauss_target_psf, _get_ellip_dilation
 import galsim
 import lsst.afw.image as afw_image
 from .util import (
@@ -14,7 +14,9 @@ INTERP = 'lanczos15'
 STEP = 0.01
 
 
-def get_metacal_mbexps_fixnoise(mbexp, noise_mbexp, types=None):
+def get_metacal_mbexps_fixnoise(
+    mbexp, noise_mbexp, types=None, psf_stats=None,
+):
     """
     Get metacal MultibandExposures with fixed noise
 
@@ -24,6 +26,9 @@ def get_metacal_mbexps_fixnoise(mbexp, noise_mbexp, types=None):
         The exposure data
     noise_mbexp: lsst.afw.image.MultibandExposure
         The exposure data with pure noise
+    psf_stats: array, optional
+        If sent, will be used to determine the round reconvolution kernel.
+        Must have e1, e2, T entries and be same length as mbexp
     types: list, optional
         The metacal types, e.g. ('noshear', '1p', '1m')
 
@@ -33,8 +38,12 @@ def get_metacal_mbexps_fixnoise(mbexp, noise_mbexp, types=None):
         dicts keyed by type, holding exposures
     """
 
-    mdict = get_metacal_mbexps(mbexp=mbexp, types=types)
-    noise_mdict = get_metacal_mbexps(mbexp=noise_mbexp, types=types, rot=True)
+    mdict = get_metacal_mbexps(
+        mbexp=mbexp, psf_stats=psf_stats, types=types,
+    )
+    noise_mdict = get_metacal_mbexps(
+        mbexp=noise_mbexp, psf_stats=psf_stats, types=types, rot=True,
+    )
     for shear_type in mdict:
         for exp, nexp in zip(mdict[shear_type], noise_mdict[shear_type]):
             exp.image.array[:, :] += nexp.image.array[:, :]
@@ -43,7 +52,7 @@ def get_metacal_mbexps_fixnoise(mbexp, noise_mbexp, types=None):
     return mdict, noise_mdict
 
 
-def get_metacal_mbexps(mbexp, types=None, rot=False):
+def get_metacal_mbexps(mbexp, types=None, rot=False, psf_stats=None):
     """
     Get metacal MultibandExposures
 
@@ -51,6 +60,9 @@ def get_metacal_mbexps(mbexp, types=None, rot=False):
     ----------
     mbexp: lsst.afw.image.MultibandExposure
         The exposure data
+    psf_stats: array, optional
+        If sent, will be used to determine the round reconvolution kernel.
+        Must have e1, e2, T entries and be same length as mbexp
     types: list, optional
         The metacal types, e.g. ('noshear', '1p', '1m')
     rot: bool, optional
@@ -65,6 +77,12 @@ def get_metacal_mbexps(mbexp, types=None, rot=False):
     if types is None:
         types = DEFAULT_TYPES
 
+    if psf_stats is not None:
+        assert len(psf_stats) == len(mbexp), (
+            f'psf_stats with len {len(psf_stats)} is '
+            f'a mismatch for mbexp len {len(mbexp)}'
+        )
+
     mdict_with_explists = {}
     for shear_type in types:
         mdict_with_explists[shear_type] = []
@@ -72,7 +90,14 @@ def get_metacal_mbexps(mbexp, types=None, rot=False):
     for iband, band in enumerate(mbexp.bands):
         exp = mbexp[band]
 
-        this_mdict = get_metacal_exps(exp, types=types, rot=rot)
+        if psf_stats is not None:
+            psf_band_stats = psf_stats[iband]
+        else:
+            psf_band_stats = None
+
+        this_mdict = get_metacal_exps(
+            exp, psf_stats=psf_band_stats, types=types, rot=rot,
+        )
 
         for shear_type in this_mdict:
             exp = this_mdict[shear_type]
@@ -87,7 +112,7 @@ def get_metacal_mbexps(mbexp, types=None, rot=False):
     return mdict
 
 
-def get_metacal_exps_fixnoise(exp, noise_exp, types=None):
+def get_metacal_exps_fixnoise(exp, noise_exp, psf_stats=None, types=None):
     """
     Get metacal exposures with fixed noise
 
@@ -97,6 +122,9 @@ def get_metacal_exps_fixnoise(exp, noise_exp, types=None):
         The exposure data
     noise_exp: lsst.afw.image.Exposure
         The exposure data with pure noise
+    psf_stats: array, optional
+        If sent, will be used to determine the round reconvolution kernel.
+        Must have e1, e2, T entries
     types: list, optional
         The metacal types, e.g. ('noshear', '1p', '1m')
 
@@ -107,8 +135,12 @@ def get_metacal_exps_fixnoise(exp, noise_exp, types=None):
     if types is None:
         types = DEFAULT_TYPES
 
-    mdict = get_metacal_exps(exp, types=types)
-    noise_mdict = get_metacal_exps(noise_exp, types=types, rot=True)
+    mdict = get_metacal_exps(
+        exp, psf_stats=psf_stats, types=types,
+    )
+    noise_mdict = get_metacal_exps(
+        noise_exp, psf_stats=psf_stats, types=types, rot=True,
+    )
 
     for shear_type in types:
         exp = mdict[shear_type]
@@ -120,7 +152,7 @@ def get_metacal_exps_fixnoise(exp, noise_exp, types=None):
     return mdict, noise_mdict
 
 
-def get_metacal_exps(exp, types=None, rot=False):
+def get_metacal_exps(exp, psf_stats=None, types=None, rot=False):
     """
     Get metacal exposures
 
@@ -128,6 +160,9 @@ def get_metacal_exps(exp, types=None, rot=False):
     ----------
     exp: lsst.afw.image.Exposure
         The exposure data
+    psf_stats: array, optional
+        If sent, will be used to determine the round reconvolution kernel.
+        Must have e1, e2, T entries
     types: list, optional
         The metacal types, e.g. ('noshear', '1p', '1m')
     rot: bool, optional
@@ -167,7 +202,15 @@ def get_metacal_exps(exp, types=None, rot=False):
         galsim.Deconvolve(psf_int),
     )
 
-    gauss_psf = _get_gauss_target_psf(psf_int, flux=psf_flux)
+    if psf_stats is not None:
+        gauss_psf = _get_fitgauss_target_psf(
+            e1=psf_stats['e1'],
+            e2=psf_stats['e2'],
+            T=psf_stats['T'],
+            flux=psf_flux,
+        )
+    else:
+        gauss_psf = _get_gauss_target_psf(psf_int, flux=psf_flux)
 
     dilation = 1.0 + 2.0*STEP
     psf_dilated = gauss_psf.dilate(dilation)
@@ -279,3 +322,14 @@ def get_psf_kernel_image(exp, cen):
     """
     psf_obj = exp.getPsf()
     return psf_obj.computeKernelImage(cen).array
+
+
+def _get_fitgauss_target_psf(e1, e2, T, flux):
+    dilation = _get_ellip_dilation(e1, e2, T)
+    T_dilated = T * dilation
+    sigma = np.sqrt(T_dilated / 2.0)
+
+    return galsim.Gaussian(
+        sigma=sigma,
+        flux=flux,
+    )

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -215,11 +215,11 @@ class MetadetectTask(Task):
                 mbexp=mbexp, thresh=self.config.detect.thresholdValue
             )
 
-        psf_stats_perband = fit_original_psfs_mbexp(
+        psf_stats_perband = _fit_original_psfs_mbexp(
             mbexp=mbexp,
             rng=rng,
         )
-        psf_stats = average_psf_stats(
+        psf_stats = _average_psf_stats(
             psf_stats=psf_stats_perband,
             wgts=wgts,
         )
@@ -516,7 +516,7 @@ def get_mfrac_mbexp(mbexp, mfrac_mbexp):
     return mfrac, wgts
 
 
-def fit_original_psfs_mbexp(mbexp, rng):
+def _fit_original_psfs_mbexp(mbexp, rng):
     """
     fit the original psfs at the center of the image for each band
 
@@ -585,14 +585,14 @@ def fit_original_psfs_mbexp(mbexp, rng):
     return perband
 
 
-def average_psf_stats(psf_stats, wgts):
+def _average_psf_stats(psf_stats, wgts):
     """
     Compute the weighted verage of psf stats over bands.
 
     Parameters
     ----------
     psf_stats: numpy structured array
-        Per-band PSF stats as returned by fit_original_psfs_mbexp.
+        Per-band PSF stats as returned by _fit_original_psfs_mbexp.
         Array has fields: e1, e2, T, flags
     wgts: list
         Per-band weights, indexed by band position (same order as psf_stats).

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 import ngmix
-from ngmix.gexceptions import BootPSFFailure
+from ngmix.gexceptions import BootPSFFailure, GMixRangeError
 from lsst.pex.config import (
     Config,
     ConfigField,
@@ -510,8 +510,8 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
     runner = ngmix.runners.PSFRunner(fitter=fitter, guesser=guesser, ntry=4)
 
     try:
-        g1sum = 0.0
-        g2sum = 0.0
+        e1sum = 0.0
+        e2sum = 0.0
         Tsum = 0.0
 
         for exp, wgt in zip(mbexp, wgts):
@@ -536,27 +536,31 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
             if res['flags'] != 0:
                 raise BootPSFFailure('failed to fit psf')
 
-            g1, g2 = res['e']
+            e1, e2 = res['e']
             T = res['T']
 
-            g1sum += g1 * wgt
-            g2sum += g2 * wgt
+            e1sum += e1 * wgt
+            e2sum += e2 * wgt
             Tsum += T * wgt
 
-        g1 = g1sum / wsum
-        g2 = g2sum / wsum
+        e1 = e1sum / wsum
+        e2 = e2sum / wsum
         T = Tsum / wsum
 
         flags = 0
 
-    except BootPSFFailure:
+        g1, g2 = ngmix.shape.e1e2_to_g1g2(e1=e1, e2=e2)
+
+    except (BootPSFFailure, GMixRangeError):
         flags = procflags.PSF_FAILURE
-        g1 = -9999.0
-        g2 = -9999.0
+        e1 = -9999.0
+        e2 = -9999.0
         T = -9999.0
 
     return {
         'flags': flags,
+        'e1': e1,
+        'e2': e2,
         'g1': g1,
         'g2': g2,
         'T': T,

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -5,6 +5,7 @@ from ngmix.gexceptions import BootPSFFailure, GMixRangeError
 from lsst.pex.config import (
     Config,
     ConfigField,
+    ChoiceField,
     ConfigurableField,
     Field,
     FieldValidationError,
@@ -116,6 +117,15 @@ class MetacalConfig(Config):
         ],
     )
 
+    reconv_type = ChoiceField[str](
+        doc="Type of reconvolution kernel to use",
+        default="fitgauss",
+        allowed={
+            "fitgauss": "Use a gaussian fit to determine reconvolution kernel",
+            "gauss": "Use k-space power to determine reconvolution kernel",
+        },
+    )
+
     def validate(self):
         super().validate()
         if not set(self.types).issubset({"noshear", "1p", "1m", "2p", "2m"}):
@@ -216,6 +226,7 @@ class MetadetectTask(Task):
         mdict, _ = get_metacal_mbexps_fixnoise(
             mbexp=mbexp,
             noise_mbexp=noise_mbexp,
+            psf_stats=psf_stats['perband'],
             types=metacal_types,
         )
 
@@ -496,7 +507,8 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
     This can fail and flags will be set, but we proceed
     """
 
-    assert len(wgts) == len(mbexp)
+    nband = len(mbexp)
+    assert len(wgts) == nband
     wsum = sum(wgts)
     if wsum <= 0:
         raise ValueError(f'got sum(wgts) = {wsum}')
@@ -509,12 +521,16 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
     )
     runner = ngmix.runners.PSFRunner(fitter=fitter, guesser=guesser, ntry=4)
 
+    perband = np.zeros(
+        nband, dtype=[('e1', 'f8'), ('e2', 'f8'), ('T', 'f8')]
+    )
+
     try:
         e1sum = 0.0
         e2sum = 0.0
         Tsum = 0.0
 
-        for exp, wgt in zip(mbexp, wgts):
+        for iband, exp, wgt in zip(range(nband), mbexp, wgts):
             cen, _ = get_integer_center(
                 wcs=exp.getWcs(),
                 bbox=exp.getBBox(),
@@ -543,6 +559,10 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
             e2sum += e2 * wgt
             Tsum += T * wgt
 
+            perband['e1'][iband] = e1
+            perband['e2'][iband] = e2
+            perband['T'][iband] = T
+
         e1 = e1sum / wsum
         e2 = e2sum / wsum
         T = Tsum / wsum
@@ -557,6 +577,8 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
         e2 = -9999.0
         T = -9999.0
 
+        perband = None
+
     return {
         'flags': flags,
         'e1': e1,
@@ -564,4 +586,5 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
         'g1': g1,
         'g2': g2,
         'T': T,
+        'perband': perband,
     }

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -2,6 +2,7 @@ import logging
 import numpy as np
 import ngmix
 from ngmix.gexceptions import BootPSFFailure, GMixRangeError
+import lsst.geom as geom
 from lsst.pex.config import (
     Config,
     ConfigField,
@@ -38,6 +39,7 @@ def run_metadetect(
     ormasks=None,
     config=None,
     show=False,
+    border=0,
 ):
     """
     Run metadetection on the input MultiBandObsList
@@ -71,6 +73,9 @@ def run_metadetect(
         in this dict override defaults; see lsst_configs.py
     show: bool, optional
         if set to True images will be shown
+    border: int, optional
+        If positive, detections whose centroids lie ``border`` pixels away from
+        the bounding box edge of ``mbexp`` will be excluded for measurement.
 
     Returns
     -------
@@ -96,6 +101,7 @@ def run_metadetect(
         mfrac_mbexp,
         ormasks,
         show=show,
+        border=border,
     )
     return result
 
@@ -190,6 +196,7 @@ class MetadetectTask(Task):
         mfrac_mbexp=None,
         ormasks=None,
         show=False,
+        border=0,
     ):
         # This is to support methods that are not yet refactored.
         config = self.config.toDict()
@@ -245,6 +252,7 @@ class MetadetectTask(Task):
                 config=config,
                 rng=rng,
                 show=show,
+                border=border,
             )
 
             if res is not None:
@@ -274,6 +282,7 @@ def detect_deblend_and_measure(
     config,
     rng,
     show=False,
+    border=0,
 ):
     """
     run detection, deblending and measurements.
@@ -293,6 +302,9 @@ def detect_deblend_and_measure(
         Random number generator
     show: bool, optional
         If set to True, show images during processing
+    border: bool, optional
+        If positive, detections whose centroids lie ``border`` pixels away from
+        the bounding box edge of ``mbexp`` will be excluded for measurement.
     """
 
     LOG.info('measuring with blended stamps')
@@ -303,6 +315,12 @@ def detect_deblend_and_measure(
         thresh=config['detect']['thresh'],
         show=show,
     )
+
+    if border > 0:
+        inner_bbox = geom.Box2D(detexp.getBBox()).erodedBy(border)
+        sources = sources.copy(deep=not sources.isContiguous())
+        within_border = inner_bbox.contains(sources.getX(), sources.getY())
+        sources = sources[within_border]
 
     results = measure.measure(
         mbexp=mbexp,

--- a/metadetect/lsst/metadetect.py
+++ b/metadetect/lsst/metadetect.py
@@ -215,18 +215,26 @@ class MetadetectTask(Task):
                 mbexp=mbexp, thresh=self.config.detect.thresholdValue
             )
 
-        psf_stats = fit_original_psfs_mbexp(
+        psf_stats_perband = fit_original_psfs_mbexp(
             mbexp=mbexp,
-            wgts=wgts,
             rng=rng,
+        )
+        psf_stats = average_psf_stats(
+            psf_stats=psf_stats_perband,
+            wgts=wgts,
         )
 
         metacal_types = config['metacal'].get('types', None)
 
+        if config['metacal']['reconv_type'] == 'fitgauss':
+            perband_psf_stats = psf_stats_perband
+        else:
+            perband_psf_stats = None
+
         mdict, _ = get_metacal_mbexps_fixnoise(
             mbexp=mbexp,
             noise_mbexp=noise_mbexp,
-            psf_stats=psf_stats['perband'],
+            psf_stats=perband_psf_stats,
             types=metacal_types,
         )
 
@@ -248,6 +256,15 @@ class MetadetectTask(Task):
                 add_original_psf(psf_stats, res)
 
             result[shear_str] = res
+
+        # For additional information needed only for unit tests, include them
+        # under a catch-all key called '_diagnostics'. The calling code must
+        # not rely on this key being present or having the same structure.
+        result['_diagnostics'] = {
+            'psf_stats_perband': psf_stats_perband,
+            'weight_perband': {band: wgt for band, wgt in zip(mbexp.bands, wgts)},
+            'psf_stats_average': psf_stats,
+        }
 
         return result
 
@@ -499,19 +516,13 @@ def get_mfrac_mbexp(mbexp, mfrac_mbexp):
     return mfrac, wgts
 
 
-def fit_original_psfs_mbexp(mbexp, rng, wgts):
+def fit_original_psfs_mbexp(mbexp, rng):
     """
-    fit the original psfs at the center of the image and get the mean g1,g2,T
-    across all bands
+    fit the original psfs at the center of the image for each band
 
-    This can fail and flags will be set, but we proceed
+    Individual band fits can fail and flags will be set for that band, but
+    successful band fits are preserved.
     """
-
-    nband = len(mbexp)
-    assert len(wgts) == nband
-    wsum = sum(wgts)
-    if wsum <= 0:
-        raise ValueError(f'got sum(wgts) = {wsum}')
 
     fitter = ngmix.admom.AdmomFitter(rng=rng)
     guesser = ngmix.guessers.GMixPSFGuesser(
@@ -521,16 +532,19 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
     )
     runner = ngmix.runners.PSFRunner(fitter=fitter, guesser=guesser, ntry=4)
 
+    nband = len(mbexp.bands)
     perband = np.zeros(
-        nband, dtype=[('e1', 'f8'), ('e2', 'f8'), ('T', 'f8')]
+        nband, dtype=[
+            ('band', 'U1'),
+            ('e1', 'f8'),
+            ('e2', 'f8'),
+            ('T', 'f8'),
+            ('flags', 'i4'),
+        ]
     )
 
-    try:
-        e1sum = 0.0
-        e2sum = 0.0
-        Tsum = 0.0
-
-        for iband, exp, wgt in zip(range(nband), mbexp, wgts):
+    for iband, (band, exp) in enumerate(zip(mbexp.bands, mbexp)):
+        try:
             cen, _ = get_integer_center(
                 wcs=exp.getWcs(),
                 bbox=exp.getBBox(),
@@ -554,37 +568,87 @@ def fit_original_psfs_mbexp(mbexp, rng, wgts):
 
             e1, e2 = res['e']
             T = res['T']
+            flags = 0
 
-            e1sum += e1 * wgt
-            e2sum += e2 * wgt
-            Tsum += T * wgt
+        except BootPSFFailure:
+            flags = procflags.PSF_FAILURE
+            e1 = -9999.0
+            e2 = -9999.0
+            T = -9999.0
 
-            perband['e1'][iband] = e1
-            perband['e2'][iband] = e2
-            perband['T'][iband] = T
+        perband['band'][iband] = band
+        perband['e1'][iband] = e1
+        perband['e2'][iband] = e2
+        perband['T'][iband] = T
+        perband['flags'][iband] = flags
 
-        e1 = e1sum / wsum
-        e2 = e2sum / wsum
-        T = Tsum / wsum
+    return perband
 
-        flags = 0
 
-        g1, g2 = ngmix.shape.e1e2_to_g1g2(e1=e1, e2=e2)
+def average_psf_stats(psf_stats, wgts):
+    """
+    Compute the weighted verage of psf stats over bands.
 
-    except (BootPSFFailure, GMixRangeError):
+    Parameters
+    ----------
+    psf_stats: numpy structured array
+        Per-band PSF stats as returned by fit_original_psfs_mbexp.
+        Array has fields: e1, e2, T, flags
+    wgts: list
+        Per-band weights, indexed by band position (same order as psf_stats).
+
+    Returns
+    -------
+    dict
+        Averaged psf stats with fields flags, e1, e2, g1, g2, and T.
+
+    Notes
+    -----
+    The g1 and g2 values are computed from the average e1 and e2 values.
+    They are not averaged g1 and g2 values over bands.
+    """
+
+    if len(wgts) != len(psf_stats):
+        raise ValueError(
+            f'len(wgts) = {len(wgts)} != len(psf_stats) = {len(psf_stats)}'
+        )
+
+    if any(wgt < 0 for wgt in wgts):
+        raise ValueError(f'got negative weight: {wgts}')
+
+    # Check for any failures
+    flags = 0
+    for iband in range(len(psf_stats)):
+        if wgts[iband] > 0:
+            flags |= psf_stats['flags'][iband]
+
+    if flags != 0:
+        return {
+            'flags': flags,
+            'e1': -9999.0,
+            'e2': -9999.0,
+            'g1': -9999.0,
+            'g2': -9999.0,
+            'T': -9999.0,
+        }
+
+    average_psf_stats = {'flags': 0}
+    for key in ('e1', 'e2', 'T'):
+        average_psf_stats[key] = sum(
+            psf_stats[key][iband] * wgts[iband] for iband in range(len(psf_stats))
+        ) / sum(wgts)
+
+    try:
+        g1, g2 = ngmix.shape.e1e2_to_g1g2(
+            e1=average_psf_stats['e1'],
+            e2=average_psf_stats['e2'],
+        )
+    except GMixRangeError:
         flags = procflags.PSF_FAILURE
-        e1 = -9999.0
-        e2 = -9999.0
-        T = -9999.0
+        g1 = -9999.0
+        g2 = -9999.0
 
-        perband = None
+    average_psf_stats['g1'] = g1
+    average_psf_stats['g2'] = g2
 
-    return {
-        'flags': flags,
-        'e1': e1,
-        'e2': e2,
-        'g1': g1,
-        'g2': g2,
-        'T': T,
-        'perband': perband,
-    }
+    return average_psf_stats

--- a/metadetect/lsst/photometry.py
+++ b/metadetect/lsst/photometry.py
@@ -6,7 +6,7 @@ from .configs import get_config
 from . import measure
 from .metadetect import (
     fit_original_psfs_mbexp, get_mfrac_mbexp, combine_ormasks,
-    add_ormask, add_original_psf, add_mfrac,
+    add_ormask, add_original_psf, add_mfrac, average_psf_stats,
 )
 
 warnings.filterwarnings('ignore', category=FutureWarning)
@@ -71,10 +71,13 @@ def run_photometry(
     if config['subtract_sky']:
         subtract_sky_mbexp(mbexp=mbexp, thresh=config['detect']['thresh'])
 
-    psf_stats = fit_original_psfs_mbexp(
+    psf_stats_perband = fit_original_psfs_mbexp(
         mbexp=mbexp,
-        wgts=wgts,
         rng=rng,
+    )
+    psf_stats = average_psf_stats(
+        psf_stats=psf_stats_perband,
+        wgts=wgts,
     )
 
     sources, detexp = measure.detect_and_deblend(

--- a/metadetect/lsst/photometry.py
+++ b/metadetect/lsst/photometry.py
@@ -5,8 +5,8 @@ from .skysub import subtract_sky_mbexp
 from .configs import get_config
 from . import measure
 from .metadetect import (
-    fit_original_psfs_mbexp, get_mfrac_mbexp, combine_ormasks,
-    add_ormask, add_original_psf, add_mfrac, average_psf_stats,
+    _fit_original_psfs_mbexp, get_mfrac_mbexp, combine_ormasks,
+    add_ormask, add_original_psf, add_mfrac, _average_psf_stats,
 )
 
 warnings.filterwarnings('ignore', category=FutureWarning)
@@ -71,11 +71,11 @@ def run_photometry(
     if config['subtract_sky']:
         subtract_sky_mbexp(mbexp=mbexp, thresh=config['detect']['thresh'])
 
-    psf_stats_perband = fit_original_psfs_mbexp(
+    psf_stats_perband = _fit_original_psfs_mbexp(
         mbexp=mbexp,
         rng=rng,
     )
-    psf_stats = average_psf_stats(
+    psf_stats = _average_psf_stats(
         psf_stats=psf_stats_perband,
         wgts=wgts,
     )

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -387,6 +387,7 @@ def test_lsst_zero_weights(show=False):
                 mplt.show()
 
         resdict = run_metadetect(rng=rng, config=None, **data)
+        del resdict['_diagnostics']
 
         if do_zero:
             for shear_type, tres in resdict.items():
@@ -430,6 +431,7 @@ def test_lsst_masked_as_bright(show=False):
             data['noise_mbexp']['i'].mask.array[50:100, 50:100] |= bright
 
         resdict = run_metadetect(rng=rng, config=None, **data)
+        del resdict['_diagnostics']
 
         if show:
             import matplotlib.pyplot as mplt

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -30,7 +30,9 @@ logging.basicConfig(
 )
 
 
-def make_lsst_sim(seed, mag=20, hlr=0.5, bands=None):
+def make_lsst_sim(
+    seed, mag=20, hlr=0.5, bands=None, layout='grid', psf_type='gauss',
+):
     import descwl_shear_sims
 
     rng = np.random.RandomState(seed=seed)
@@ -43,12 +45,18 @@ def make_lsst_sim(seed, mag=20, hlr=0.5, bands=None):
         rng=rng,
         coadd_dim=coadd_dim,
         buff=20,
-        layout='grid',
+        layout=layout,
         mag=mag,
         hlr=hlr,
     )
 
-    psf = descwl_shear_sims.psfs.make_fixed_psf(psf_type='gauss')
+    if psf_type == 'ps':
+        psf = descwl_shear_sims.psfs.make_ps_psf(
+            rng=rng,
+            dim=300,
+        )
+    else:
+        psf = descwl_shear_sims.psfs.make_fixed_psf(psf_type=psf_type)
 
     sim_data = descwl_shear_sims.make_sim(
         rng=rng,
@@ -150,6 +158,62 @@ def test_lsst_metadetect_smoke(subtract_sky, metacal_types_option):
 
             assert len(res[shear][flux_name].shape) == len(bands)
             assert len(res[shear][flux_name][0]) == len(bands)
+
+
+@pytest.mark.parametrize("metacal_reconv_option", [None, "fitgauss", "gauss"])
+def test_lsst_metadetect_reconv(metacal_reconv_option):
+    rng = np.random.RandomState(seed=116)
+
+    bands = ['r', 'i']
+    sim_data = make_lsst_sim(116, bands=bands)
+    data = do_coadding(rng=rng, sim_data=sim_data, nowarp=True)
+
+    config = {}
+
+    if metacal_reconv_option is not None:
+        config['metacal'] = {}
+        config['metacal']['reconv_type'] = metacal_reconv_option
+
+    test_config = get_config(config)
+
+    if metacal_reconv_option is not None:
+        assert test_config['metacal']['reconv_type'] == metacal_reconv_option
+    else:
+        assert test_config['metacal']['reconv_type'] == 'fitgauss'
+
+    res = run_metadetect(rng=rng, config=config, **data)  # noqa
+
+
+@pytest.mark.xfail
+def test_lsst_metadetect_reconv_size():
+    """
+    This currently fails because the PSF images have no noise.  fitgauss
+    will outperform gauss for noisy PSFs
+    """
+    rng = np.random.RandomState(seed=232)
+
+    bands = ['r', 'i']
+    sim_data = make_lsst_sim(5520, bands=bands, psf_type='ps')
+    data = do_coadding(rng=rng, sim_data=sim_data, nowarp=True)
+
+    config = {}
+    config['metacal'] = {}
+    config['metacal']['reconv_type'] = 'fitgauss'
+    res_fitgauss = run_metadetect(rng=rng, config=config, **data)  # noqa
+
+    config['metacal']['reconv_type'] = 'gauss'
+    res_gauss = run_metadetect(rng=rng, config=config, **data)  # noqa
+
+    mT_fitgauss = res_fitgauss['noshear']['gauss_psf_T'].mean()
+    mT_gauss = res_gauss['noshear']['gauss_psf_T'].mean()
+
+    fwhm_fitgauss = ngmix.moments.T_to_fwhm(mT_fitgauss)
+    fwhm_gauss = ngmix.moments.T_to_fwhm(mT_gauss)
+
+    assert fwhm_fitgauss < fwhm_gauss, (
+        'expected fitgauss fwhm < gauss fwhm, '
+        f'got {fwhm_fitgauss} > {fwhm_gauss}'
+    )
 
 
 @pytest.mark.skipif(

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -50,23 +50,31 @@ def make_lsst_sim(
         hlr=hlr,
     )
 
-    if psf_type == 'ps':
-        psf = descwl_shear_sims.psfs.make_ps_psf(
-            rng=rng,
-            dim=300,
-        )
-    else:
-        psf = descwl_shear_sims.psfs.make_fixed_psf(psf_type=psf_type)
+    # This way we get different PSFs per band for PS PSF
+    sim_data = {'band_data': {}}
+    for band in bands:
+        if psf_type == 'ps':
+            psf = descwl_shear_sims.psfs.make_ps_psf(
+                rng=rng,
+                dim=300,
+            )
+        else:
+            psf = descwl_shear_sims.psfs.make_fixed_psf(psf_type=psf_type)
 
-    sim_data = descwl_shear_sims.make_sim(
-        rng=rng,
-        galaxy_catalog=galaxy_catalog,
-        coadd_dim=coadd_dim,
-        g1=0.02,
-        g2=0.00,
-        psf=psf,
-        bands=bands,
-    )
+        tsim_data = descwl_shear_sims.make_sim(
+            rng=rng,
+            galaxy_catalog=galaxy_catalog,
+            coadd_dim=coadd_dim,
+            g1=0.02,
+            g2=0.00,
+            psf=psf,
+            bands=bands,
+        )
+        for key in tsim_data:
+            if key == 'band_data':
+                sim_data['band_data'][band] = tsim_data['band_data'][band]
+            else:
+                sim_data[key] = tsim_data[key]
     return sim_data
 
 
@@ -241,15 +249,18 @@ def test_lsst_metadetect_shear_bands():
     rng = np.random.RandomState(seed=116)
 
     bands = ['g', 'r', 'i', 'z']
+    shear_bands = ['r', 'z']
+
     nband = len(bands)
-    sim_data = make_lsst_sim(116, bands=bands)
+    sim_data = make_lsst_sim(116, bands=bands, psf_type='ps')
     data = do_coadding(rng=rng, sim_data=sim_data, nowarp=True)
 
-    config = {"shear_bands": ["r", "z"]}
+    config = {"shear_bands": shear_bands}
     metacal_types = ['noshear', '1p', '1m']
 
     detected = afw_image.Mask.getPlaneBitMask('DETECTED')
     res = run_metadetect(rng=rng, config=config, **data)
+    diagnostics = res.pop('_diagnostics')
 
     # we remove the DETECTED bit
     assert np.all(res['noshear']['bmask'] & detected == 0)
@@ -273,6 +284,36 @@ def test_lsst_metadetect_shear_bands():
             assert np.any(res[shear][f"{front}_flags"] == 0)
             assert np.all(res[shear]["mfrac"] == 0)
             assert res[shear][flux_name].shape == (25, nband)
+
+    perband = diagnostics['psf_stats_perband']
+    assert perband.size == len(bands)
+
+    wgts = diagnostics['weight_perband']
+    assert len(wgts) == len(bands)
+    assert all(band in bands for band in wgts)
+    for iband, band in enumerate(bands):
+        assert perband['band'][iband] == band
+        if band in shear_bands:
+            assert wgts[band] > 0
+        else:
+            assert wgts[band] == 0
+
+    wgts_list = list(wgts.values())
+    psf_stats = diagnostics['psf_stats_average']
+    T = np.average(perband['T'], weights=wgts_list)
+    e1 = np.average(perband['e1'], weights=wgts_list)
+    e2 = np.average(perband['e2'], weights=wgts_list)
+    g1, g2 = ngmix.shape.e1e2_to_g1g2(e1, e2)
+
+    assert psf_stats['T'] == T
+    assert psf_stats['e1'] == e1
+    assert psf_stats['e2'] == e2
+    assert psf_stats['g1'] == g1
+    assert psf_stats['g2'] == g2
+
+    np.testing.assert_allclose(res['noshear']['psfrec_g'][:, 0], g1)
+    np.testing.assert_allclose(res['noshear']['psfrec_g'][:, 1], g2)
+    np.testing.assert_allclose(res['noshear']['psfrec_T'], T)
 
     for shear in metacal_types:
         assert np.all(res[shear]["shear_bands"] == np.array([["13"]]))

--- a/scripts/compare_reconv.py
+++ b/scripts/compare_reconv.py
@@ -1,0 +1,187 @@
+import numpy as np
+import galsim
+import ngmix
+from ngmix.metacal.metacal import _get_gauss_target_psf, _get_ellip_dilation
+from tqdm import tqdm
+
+
+SCALE = 0.2
+
+
+def fit_gauss(im, noise, rng):
+    fitter = ngmix.admom.AdmomFitter(rng=rng)
+    guesser = ngmix.guessers.GMixPSFGuesser(
+        rng=rng,
+        ngauss=1,
+        guess_from_moms=True,
+    )
+    runner = ngmix.runners.PSFRunner(fitter=fitter, guesser=guesser, ntry=4)
+
+    cen = (np.array(im.shape) - 1.0) / 2.0
+    jac = ngmix.DiagonalJacobian(
+        row=cen[0],
+        col=cen[1],
+        scale=SCALE,
+    )
+    obs = ngmix.Observation(
+        image=im,
+        weight=im * 0 + 1.0 / noise ** 2,
+        jacobian=jac,
+    )
+    res = runner.go(obs)
+    return res
+
+
+def get_psf(e1, e2, dim=49, scale=SCALE):
+    psf = galsim.Moffat(
+        fwhm=0.8, beta=2.5,
+    ).shear(
+        e1=e1,
+        e2=e2,
+    )
+    gsim = psf.drawImage(
+        nx=dim,
+        ny=dim,
+        dtype=np.float64,
+        scale=scale,
+    )
+
+    return psf, gsim
+
+
+def get_e1e2(rng):
+    while True:
+        e1, e2 = rng.normal(scale=0.1 / np.sqrt(2), size=2)
+        e = np.sqrt(e1 ** 2 + e2 ** 2)
+        if e < 0.9:
+            break
+    return e1, e2
+
+
+def get_Tvals(rng, noise, ntrial):
+    s2n_vals = np.zeros(ntrial)
+    Tvals = np.zeros(ntrial)
+    Tvals_fitgauss = np.zeros(ntrial)
+
+    for i in range(ntrial):
+
+        e1, e2 = get_e1e2(rng)
+
+        psf, gsim = get_psf(
+            e1=e1,
+            e2=e2,
+        )
+        gsim.array[:, :] += rng.normal(
+            scale=noise,
+            size=gsim.array.shape,
+        )
+
+        gsim_int = galsim.InterpolatedImage(
+            gsim, x_interpolant='lanczos15',
+        )
+        gauss_target_psf = _get_gauss_target_psf(
+            gsim_int,
+            flux=1.0,
+        )
+        Tvals[i] = 2 * gauss_target_psf.sigma ** 2
+
+        res = fit_gauss(
+            im=gsim.array,
+            noise=noise,
+            rng=rng,
+        )
+        dilation = _get_ellip_dilation(
+            e1=res['e'][0], e2=res['e'][1], T=res['T'],
+        )
+        T_dilated = res['T'] * dilation
+
+        Tvals_fitgauss[i] = T_dilated
+        s2n_vals[i] = res['s2n']
+
+    return Tvals, Tvals_fitgauss, s2n_vals
+
+
+def plot_fwhms(
+    s2n,
+    fwhms,
+    fwhm_errs,
+    fwhms_fitgauss,
+    fwhm_fitgauss_errs,
+):
+    from matplotlib import pyplot as mplt
+
+    fig, ax = mplt.subplots(figsize=(10, 6))
+    ax.set(
+        xlabel='S/N',
+        ylabel='fwhm [arcsec]',
+        xlim=(0.5 * s2n.min(), 1.5 * s2n.max()),
+    )
+    ax.set_xscale('log')
+
+    ax.errorbar(
+        s2n,
+        fwhms,
+        fwhm_errs,
+        label='gauss',
+    )
+    ax.errorbar(
+        s2n,
+        fwhms_fitgauss,
+        fwhm_fitgauss_errs,
+        label='fitgauss',
+    )
+    ax.text(75, 0.92, "Moffat PSF")
+
+    ax.legend()
+    output = 'fwhm-vs-s2n.pdf'
+    print('writing:', output)
+    fig.savefig(output)
+
+
+def main():
+    ntrial = 100
+    rng = np.random.RandomState()
+
+    noises = np.logspace(
+        # np.log10(0.0001),
+        np.log10(0.00001),
+        np.log10(0.001),
+        10,
+    )
+
+    s2ns = np.zeros(noises.size)
+    fwhms = np.zeros(noises.size)
+    fwhm_errs = np.zeros(noises.size)
+    fwhms_fitgauss = np.zeros(noises.size)
+    fwhm_fitgauss_errs = np.zeros(noises.size)
+
+    for i, noise in enumerate(tqdm(noises, ascii=True, ncols=70)):
+        Tvals, Tvals_fitgauss, s2n_vals = get_Tvals(
+            rng=rng,
+            noise=noise,
+            ntrial=ntrial,
+        )
+
+        s2ns[i] = s2n_vals.mean()
+
+        fwhm_vals = ngmix.moments.T_to_fwhm(Tvals)
+        fwhm_fitgauss_vals = ngmix.moments.T_to_fwhm(Tvals_fitgauss)
+
+        fwhms[i] = fwhm_vals.mean()
+        fwhm_errs[i] = fwhm_vals.std() / np.sqrt(fwhm_vals.size)
+
+        fwhms_fitgauss[i] = fwhm_fitgauss_vals.mean()
+        fwhm_fitgauss_errs[i] = (
+            fwhm_fitgauss_vals.std() / np.sqrt(fwhm_fitgauss_vals.size)
+        )
+
+    plot_fwhms(
+        s2n=s2ns,
+        fwhms=fwhms,
+        fwhm_errs=fwhm_errs,
+        fwhms_fitgauss=fwhms_fitgauss,
+        fwhm_fitgauss_errs=fwhm_fitgauss_errs,
+    )
+
+
+main()


### PR DESCRIPTION
This is a partial sync of changes upstream. It excludes running with `scarlet` which requires changes that haven't been merged to the default branch upstream. The included changes are: 

1. Switch the ellipticity convention for original PSFs.
2. Add a new `fitgauss` option for reconvolved PSF and make that the default. 
3. Update unit tests.